### PR TITLE
Adds double quotes around plan name on pre-hook for create subscription

### DIFF
--- a/actions/vindi_create_subscription.json
+++ b/actions/vindi_create_subscription.json
@@ -145,7 +145,7 @@
             "json_api": true,
             "method_name": "/plans",
             "params": [
-              {"field": "query", "value": "name:{plan_name}", "type": "string"}
+              {"field": "query", "value": "'name:\"' + data[:plan_name] + '\"'", "custom": true}
             ],
             "response_field": ["plans"],
             "error_fields": ["errors"],


### PR DESCRIPTION
According to Vindi, we need to surround the plan name parameter around double quotes on query endpoints.